### PR TITLE
Restore fwgtin/GTIN support removed in PR #6

### DIFF
--- a/Cartridges/bm_firework_dashboard/cartridge/models/fwPreferencesModel.js
+++ b/Cartridges/bm_firework_dashboard/cartridge/models/fwPreferencesModel.js
@@ -20,6 +20,7 @@ Preferences.prototype.getPreferences = function (preferencesArgs) {
         siteCurrency: preference.custom.fireworkSiteCurrency,
         siteTitle: preference.custom.fireworkSiteTitle,
         fwImageviewtype: preference.custom.fwImageviewtype,
+        fwgtin: preference.custom.fwgtin,
         fwLocaleId: preference.custom.fwLocaleId,
         getUniqueBMUID: preference.custom.fireworkUniqueBMUID,
         contactsEmail: preference.custom.fireworkContactsEmail,

--- a/Cartridges/bm_firework_dashboard/cartridge/scripts/firework/createGraphQLAPI.js
+++ b/Cartridges/bm_firework_dashboard/cartridge/scripts/firework/createGraphQLAPI.js
@@ -24,7 +24,14 @@ function createGraphFun(graphQLData) {
 	else
 	{
 		fwImageviewtype=fwImageviewtype.replace(/"/g, '\\"');
-		
+
+	}
+	// Process sfcc_gtin field
+	var sfcc_gtin = getFwConfigSetting.fwgtin;
+	if (empty(sfcc_gtin) || sfcc_gtin == null || sfcc_gtin == 'null') {
+		sfcc_gtin = '';
+	} else {
+		sfcc_gtin = sfcc_gtin.replace(/"/g, '\\"');
 	}
 	var requestLocale = getFwConfigSetting.fwLocaleId;
 	if(empty(requestLocale) || requestLocale == null || requestLocale == 'null')
@@ -67,7 +74,7 @@ function createGraphFun(graphQLData) {
 	var baseUrl = request.getHttpProtocol() + "://" + request.getHttpHost();
 	var shopBaseUrl = '/s/' + dw.system.Site.current.ID + '/dw/data/v23_1';
 	var metadata = '{\\\\\\"site_id\\\\\\": \\\\\\"' + site_id + '\\\\\\",\\\\\\"short_code\\\\\\": \\\\\\"' + short_code + '\\\\\\",\\\\\\"client_id\\\\\\": \\\\\\"' + client_id + '\\\\\\",\\\\\\"org_id\\\\\\": \\\\\\"' + org_id + '\\\\\\",\\\\\\"base_url\\\\\\": \\\\\\"' + baseUrl + '\\\\\\",\\\\\\"shop_base_url\\\\\\": \\\\\\"' + shopBaseUrl + '\\\\\\"}';
-	var query = '{"query":"mutation {\\n\\t\\t\\t\\t\\tcreateBusinessStore(createBusinessStoreInput: {businessId: \\"' + businessId + '\\", currency: \\"' + currency + '\\", name: \\"' + siteTitle + '\\", provider: \\"salesforce\\", uid: \\"' + uid + '\\", url: \\"' + siteUrl + '\\", accessToken: \\"' + accessToken + '\\", imageViewTypes:[' + fwImageviewtype + '], siteLocaleId: \\"' + requestLocale + '\\", metadata: \\"' + metadata + '\\"\\n    }) {\\n\\t\\t\\t\\t\\t... on BusinessStore {\\n\\t\\t\\t\\t\\t\\t\\tid\\n\\t\\t\\t\\t\\t\\t\\tname\\n\\t\\t\\t\\t\\t\\t\\tprovider\\n\\t\\t\\t\\t\\t\\t\\tcurrency\\n\\t\\t\\t\\t\\t\\t\\turl\\n\\t\\t\\t\\t\\t\\t\\taccessToken\\n\\t\\t\\t\\t\\t\\t\\trefreshToken\\n        }\\n\\t\\t\\t\\t\\t\\t... on AnyError {\\n\\t\\t\\t\\t\\t\\t\\tmessage\\n        }\\n    }\\n}","variables":{}}';
+	var query = '{"query":"mutation {\\n\\t\\t\\t\\t\\tcreateBusinessStore(createBusinessStoreInput: {businessId: \\"' + businessId + '\\", currency: \\"' + currency + '\\", name: \\"' + siteTitle + '\\", provider: \\"salesforce\\", uid: \\"' + uid + '\\", url: \\"' + siteUrl + '\\", accessToken: \\"' + accessToken + '\\", imageViewTypes:[' + fwImageviewtype + '], sfcc_gtin: \\"' + sfcc_gtin + '\\", siteLocaleId: \\"' + requestLocale + '\\", metadata: \\"' + metadata + '\\"\\n    }) {\\n\\t\\t\\t\\t\\t... on BusinessStore {\\n\\t\\t\\t\\t\\t\\t\\tid\\n\\t\\t\\t\\t\\t\\t\\tname\\n\\t\\t\\t\\t\\t\\t\\tprovider\\n\\t\\t\\t\\t\\t\\t\\tcurrency\\n\\t\\t\\t\\t\\t\\t\\turl\\n\\t\\t\\t\\t\\t\\t\\taccessToken\\n\\t\\t\\t\\t\\t\\t\\trefreshToken\\n        }\\n\\t\\t\\t\\t\\t\\t... on AnyError {\\n\\t\\t\\t\\t\\t\\t\\tmessage\\n        }\\n    }\\n}","variables":{}}';
 	var Site = require('dw/system/Site');
 	var URLUtils = require('dw/web/URLUtils');
 	var restService = require('~/cartridge/scripts/init/FireWorkInit');

--- a/Cartridges/bm_firework_dashboard/cartridge/scripts/firework/updateGraphQLAPI.js
+++ b/Cartridges/bm_firework_dashboard/cartridge/scripts/firework/updateGraphQLAPI.js
@@ -17,6 +17,15 @@ function updateGraphFun(graphQLData)
 	/* API Includes */
 	var preferencesModel = new PreferencesModel();
     var getFwConfigSetting=preferencesModel.getPreferences();
+
+	// Process sfcc_gtin field
+	var sfcc_gtin = getFwConfigSetting.fwgtin;
+	if (empty(sfcc_gtin) || sfcc_gtin == null || sfcc_gtin == 'null') {
+		sfcc_gtin = '';
+	} else {
+		sfcc_gtin = sfcc_gtin.replace(/"/g, '\\"');
+	}
+
 	var fwImageviewtype=getFwConfigSetting.fwImageviewtype;
 	if(empty(fwImageviewtype) || fwImageviewtype == null || fwImageviewtype == 'null')
 	{
@@ -71,7 +80,7 @@ function updateGraphFun(graphQLData)
 			var restService = require('~/cartridge/scripts/init/FireWorkInit');
 			var htmlError = '<div id="saErroroauthRegister">Something went wrong.</div>';
 			var service:Service =restService.graphQLCredService;
-			var query = '{"query":"mutation {updateBusinessStore(storeId: \\"'+ storeId +'\\", updateBusinessStoreInput: {businessId: \\"'+ businessId +'\\", accessToken: \\"'+ accessToken +'\\", imageViewTypes:[' + fwImageviewtype + '] , siteLocaleId: \\"' + requestLocale + '\\", name: \\"'+ siteTitle +'\\"\\n }) {... on BusinessStore {\\n\\t\\t\\t\\t\\t\\t\\t\\tid\\n\\t\\t\\t\\t\\t\\t\\t\\tname\\n\\t\\t\\t\\t\\t\\t\\t\\tprovider\\n\\t\\t\\t\\t\\t\\t\\t\\tcurrency\\n\\t\\t\\t\\t\\t\\t\\t\\turl\\n\\t\\t\\t\\t\\t\\t\\t\\taccessToken\\n\\t\\t\\t\\t\\t\\t\\t\\tuid\\n\\t\\t\\t\\t\\t\\t\\t\\trefreshToken\\n        }... on AnyError {\\n\\t\\t\\t\\t\\t\\t\\t\\tmessage\\n        }\\n    }\\n}","variables":{}}';
+			var query = '{"query":"mutation {updateBusinessStore(storeId: \\"'+ storeId +'\\", updateBusinessStoreInput: {businessId: \\"'+ businessId +'\\", accessToken: \\"'+ accessToken +'\\", imageViewTypes:[' + fwImageviewtype + '], sfcc_gtin: \\"' + sfcc_gtin + '\\", siteLocaleId: \\"' + requestLocale + '\\", name: \\"'+ siteTitle +'\\"\\n }) {... on BusinessStore {\\n\\t\\t\\t\\t\\t\\t\\t\\tid\\n\\t\\t\\t\\t\\t\\t\\t\\tname\\n\\t\\t\\t\\t\\t\\t\\t\\tprovider\\n\\t\\t\\t\\t\\t\\t\\t\\tcurrency\\n\\t\\t\\t\\t\\t\\t\\t\\turl\\n\\t\\t\\t\\t\\t\\t\\t\\taccessToken\\n\\t\\t\\t\\t\\t\\t\\t\\tuid\\n\\t\\t\\t\\t\\t\\t\\t\\trefreshToken\\n        }... on AnyError {\\n\\t\\t\\t\\t\\t\\t\\t\\tmessage\\n        }\\n    }\\n}","variables":{}}';
 			service.URL += '/graphiql';
 			var payLoadDetails=new Bytes(query);
     		var result:Result = service.call({


### PR DESCRIPTION
## Summary
- Restores `fwgtin` preference field in `fwPreferencesModel.js`
- Restores `sfcc_gtin` field processing in `createGraphQLAPI.js` and `updateGraphQLAPI.js`
- Restores `sfcc_gtin` parameter in both `createBusinessStore` and `updateBusinessStore` GraphQL mutations

These changes were accidentally removed during the multi-currency hydration merge (PR #6).

## Test plan
- [ ] Verify GTIN field is available in BM preferences
- [ ] Verify create store GraphQL mutation includes sfcc_gtin
- [ ] Verify update store GraphQL mutation includes sfcc_gtin

🤖 Generated with [Claude Code](https://claude.com/claude-code)